### PR TITLE
Don't mark 3XX status code as not successful

### DIFF
--- a/Listener/HttpRequestListener.php
+++ b/Listener/HttpRequestListener.php
@@ -78,7 +78,7 @@ final class HttpRequestListener implements EventSubscriberInterface
             $this->request,
             (int) round(microtime(true) * 1000, 1) - $this->requestStartTimeMs,
             $response->getStatusCode(),
-            $response->isSuccessful(),
+            $response->isSuccessful() || $response->isRedirection(),
             $event->getRequest()->query->all()
         );
     }


### PR DESCRIPTION
This pull request resolve #6 .

The response is considered as successful whenever HttpResponse si successful or redirection.