### PR TITLE
Added possibility to cache failed app insights flushes

### DIFF
--- a/DependencyInjection/AppInsightsPHPExtension.php
+++ b/DependencyInjection/AppInsightsPHPExtension.php
@@ -14,6 +14,11 @@ declare(strict_types=1);
 namespace AppInsightsPHP\Symfony\AppInsightsPHPBundle\DependencyInjection;
 
 use AppInsightsPHP\Client\Client;
+use AppInsightsPHP\Client\Configuration;
+use AppInsightsPHP\Client\Configuration\Dependenies;
+use AppInsightsPHP\Client\Configuration\Exceptions;
+use AppInsightsPHP\Client\Configuration\Requests;
+use AppInsightsPHP\Client\Configuration\Traces;
 use AppInsightsPHP\Monolog\Handler\AppInsightsDependencyHandler;
 use AppInsightsPHP\Monolog\Handler\AppInsightsTraceHandler;
 use Symfony\Component\Config\FileLocator;
@@ -38,7 +43,7 @@ final class AppInsightsPHPExtension extends Extension
 
         if ((bool) $config['fallback_logger']) {
             $container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')
-                ->replaceArgument(1, new Reference($config['fallback_logger']['service_id']));
+                ->replaceArgument(2, new Reference($config['fallback_logger']['service_id']));
 
             if (isset($config['fallback_logger']['monolog_channel'])) {
                 $container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')
@@ -46,32 +51,37 @@ final class AppInsightsPHPExtension extends Extension
             }
         }
 
+        if (isset($config['failure_cache_service_id'])) {
+            $container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')
+                ->replaceArgument(1, new Reference($config['failure_cache_service_id']));
+        }
+
         // Make autowiring possible
         $container->setAlias(Client::class, 'app_insights_php.telemetry')->setPublic(true);
 
         $container->setDefinition('app_insights_php.configuration.exceptions',
-            new Definition(\AppInsightsPHP\Client\Configuration\Exceptions::class, [
+            new Definition(Exceptions::class, [
                 $config['exceptions']['enabled'],
                 (array) $config['exceptions']['ignored_exceptions'],
             ])
         );
         $container->setDefinition('app_insights_php.configuration.dependencies',
-            new Definition(\AppInsightsPHP\Client\Configuration\Dependenies::class, [
+            new Definition(Dependenies::class, [
                 $config['dependencies']['enabled'],
             ])
         );
         $container->setDefinition('app_insights_php.configuration.requests',
-            new Definition(\AppInsightsPHP\Client\Configuration\Requests::class, [
+            new Definition(Requests::class, [
                 $config['requests']['enabled'],
             ])
         );
         $container->setDefinition('app_insights_php.configuration.traces',
-            new Definition(\AppInsightsPHP\Client\Configuration\Traces::class, [
+            new Definition(Traces::class, [
                 $config['traces']['enabled'],
             ])
         );
         $container->setDefinition('app_insights_php.configuration',
-            new Definition(\AppInsightsPHP\Client\Configuration::class, [
+            new Definition(Configuration::class, [
                 $config['enabled'],
                 new Reference('app_insights_php.configuration.exceptions'),
                 new Reference('app_insights_php.configuration.dependencies'),

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -37,6 +37,7 @@ final class Configuration implements ConfigurationInterface
                         ->scalarNode('monolog_channel')->end()
                     ->end()
                 ->end()
+                ->scalarNode('failure_cache_service_id')->end()
                 ->arrayNode('exceptions')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/Listener/KernelTerminateListener.php
+++ b/Listener/KernelTerminateListener.php
@@ -53,7 +53,7 @@ final class KernelTerminateListener implements EventSubscriberInterface
     {
         if (!\count($this->telemetryClient->getChannel()->getQueue())) {
             // telemetry client queue is empty
-            return ;
+            return;
         }
 
         try {
@@ -69,17 +69,16 @@ final class KernelTerminateListener implements EventSubscriberInterface
 
             $this->telemetryClient->flush();
         } catch (\Throwable $e) {
-
             if ($this->failureCache) {
                 $queueContent = $this->telemetryClient->getChannel()->getQueue();
 
                 if ($this->failureCache->has(self::CACHE_CHANNEL_KEY)) {
-                    $previousQueueContent = \unserialize($this->failureCache->get(self::CACHE_CHANNEL_KEY));
+                    $previousQueueContent = unserialize($this->failureCache->get(self::CACHE_CHANNEL_KEY));
 
                     $queueContent = array_merge($previousQueueContent, $queueContent);
                 }
 
-                $this->failureCache->set(self::CACHE_CHANNEL_KEY, \serialize($queueContent), self:: CACHE_CHANNEL_TTL_SEC);
+                $this->failureCache->set(self::CACHE_CHANNEL_KEY, serialize($queueContent), self:: CACHE_CHANNEL_TTL_SEC);
             }
 
             if ($this->logger) {

--- a/Listener/KernelTerminateListener.php
+++ b/Listener/KernelTerminateListener.php
@@ -15,19 +15,25 @@ namespace AppInsightsPHP\Symfony\AppInsightsPHPBundle\Listener;
 
 use AppInsightsPHP\Client\Client;
 use Psr\Log\LoggerInterface;
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 final class KernelTerminateListener implements EventSubscriberInterface
 {
+    public const CACHE_CHANNEL_KEY = 'app_insights_php.failure_cache';
+    public const CACHE_CHANNEL_TTL_SEC = 86400; // 1 day
+
     private $telemetryClient;
     private $logger;
+    private $failureCache;
 
-    public function __construct(Client $telemetryClient, LoggerInterface $logger = null)
+    public function __construct(Client $telemetryClient, CacheInterface $failureCache = null, LoggerInterface $logger = null)
     {
         $this->telemetryClient = $telemetryClient;
         $this->logger = $logger;
+        $this->failureCache = $failureCache;
     }
 
     public static function getSubscribedEvents()
@@ -45,9 +51,37 @@ final class KernelTerminateListener implements EventSubscriberInterface
 
     public function onTerminate()
     {
+        if (!\count($this->telemetryClient->getChannel()->getQueue())) {
+            // telemetry client queue is empty
+            return ;
+        }
+
         try {
+            if ($this->failureCache && $this->failureCache->has(self::CACHE_CHANNEL_KEY)) {
+                $queueContent = unserialize($this->failureCache->get(self::CACHE_CHANNEL_KEY));
+
+                $queueContent = array_merge($queueContent, $this->telemetryClient->getChannel()->getQueue());
+
+                $this->telemetryClient->getChannel()->setQueue($queueContent);
+
+                $this->failureCache->delete(self::CACHE_CHANNEL_KEY);
+            }
+
             $this->telemetryClient->flush();
         } catch (\Throwable $e) {
+
+            if ($this->failureCache) {
+                $queueContent = $this->telemetryClient->getChannel()->getQueue();
+
+                if ($this->failureCache->has(self::CACHE_CHANNEL_KEY)) {
+                    $previousQueueContent = \unserialize($this->failureCache->get(self::CACHE_CHANNEL_KEY));
+
+                    $queueContent = array_merge($previousQueueContent, $queueContent);
+                }
+
+                $this->failureCache->set(self::CACHE_CHANNEL_KEY, \serialize($queueContent), self:: CACHE_CHANNEL_TTL_SEC);
+            }
+
             if ($this->logger) {
                 $this->logger->error(
                     sprintf('Exception occurred while flushing App Insights Telemetry Client: %s', $e->getMessage()),

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ If you are looking for a SAAS alternative to:
 * New Relic / Datadog / etc 
 * Google Analytics 
 
-With 90 days data retention period for ~2.5EUR per 5GB [Pricing](https://azure.microsoft.com/en-us/pricing/details/monitor/)
+With 90 days data retention period for ~2.5EUR per GB [Pricing](https://azure.microsoft.com/en-us/pricing/details/monitor/)
+First 5GB are free for 31 days..
 Microsoft App Insights is exactly what you need. 
 
 This bundle simplifies App Insights integration with your new or existing project. 

--- a/Resources/config/app_insights_php.xml
+++ b/Resources/config/app_insights_php.xml
@@ -23,7 +23,8 @@
 
         <service id="app_insights_php.symfony.listener.kernel_terminate" class="AppInsightsPHP\Symfony\AppInsightsPHPBundle\Listener\KernelTerminateListener">
             <argument type="service" id="app_insights_php.telemetry" />
-            <argument/>
+            <argument/> <!-- Replaced by AppInsightsPHPBundleExtension - cache -->
+            <argument/> <!-- Replaced by AppInsightsPHPBundleExtension - logger -->
 
             <tag name="kernel.event_subscriber" />
         </service>

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -75,6 +75,7 @@ app_insights_php:
   fallback_logger:         # optional
     service_id: "logger"   # optional 
     monolog_logger: "main" # optional 
+  failure_cache_service_id: "your_cache_service_id" # optional
   exceptions:
     enabled: true
     ignored_exceptions:
@@ -106,10 +107,21 @@ monolog:
       id: "app_insights_php.monolog.handler.trace"
 ```
 
+#### fallback_logger
+
 When most of the configuration is pretty much self descriptive `fallback_logger` might need some extra explanation. 
 Fallback logger is used to log failures in app insights logger. It's used by `KernelTerminateListener`.
 
 You can configure only `service_id` or if using MonologBundle also `monolog_channel`. 
+
+### failure_cache_service_id
+
+It happens that from time to time app insights API returns 500 server error. In that case if you use fallback_logger 
+error will be logged but you will also loose anything that supposed to be logged during that failed attempt. 
+
+Failure cache (implementation of \PSR\SimpleCache\CacheInterface) will take whole queue during exception, it will serialize
+it and save for next 24 hours in the cache. During next `onTerminate` with not empty Telemetry client queue content
+of the cache will be deserialized and attached to the upcoming flush.  
 
 ### Step 5: How it works
 

--- a/Tests/DependencyInjection/AppInsightsPHPExtensionTest.php
+++ b/Tests/DependencyInjection/AppInsightsPHPExtensionTest.php
@@ -90,7 +90,7 @@ final class AppInsightsPHPExtensionTest extends TestCase
 
         $this->assertSame(
             'logger',
-            (string) $this->container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')->getArgument(1)
+            (string) $this->container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')->getArgument(2)
         );
     }
 
@@ -110,11 +110,29 @@ final class AppInsightsPHPExtensionTest extends TestCase
 
         $this->assertSame(
             'logger',
-            (string) $this->container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')->getArgument(1)
+            (string) $this->container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')->getArgument(2)
         );
         $this->assertSame(
             'main',
             $this->container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')->getTag('monolog.logger')[0]['channel']
+        );
+    }
+
+
+    public function test_failure_cache_configuration()
+    {
+        $extension = new AppInsightsPHPExtension();
+        $extension->load(
+            [[
+                'instrumentation_key' => 'test_key',
+                'failure_cache_service_id' => 'failure_cache_id'
+            ]],
+            $this->container
+        );
+
+        $this->assertSame(
+            'failure_cache_id',
+            (string) $this->container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')->getArgument(1)
         );
     }
 

--- a/Tests/DependencyInjection/AppInsightsPHPExtensionTest.php
+++ b/Tests/DependencyInjection/AppInsightsPHPExtensionTest.php
@@ -118,14 +118,13 @@ final class AppInsightsPHPExtensionTest extends TestCase
         );
     }
 
-
     public function test_failure_cache_configuration()
     {
         $extension = new AppInsightsPHPExtension();
         $extension->load(
             [[
                 'instrumentation_key' => 'test_key',
-                'failure_cache_service_id' => 'failure_cache_id'
+                'failure_cache_service_id' => 'failure_cache_id',
             ]],
             $this->container
         );

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -72,7 +72,7 @@ final class ConfigurationTest extends Testcase
         $configs = [
             [
                 'instrumentation_key' => 'test_key',
-                'failure_cache_service_id' => 'failure_cache_id'
+                'failure_cache_service_id' => 'failure_cache_id',
             ],
         ];
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -67,6 +67,20 @@ final class ConfigurationTest extends Testcase
         $this->assertEquals('dependency', $config['monolog']['handlers']['bar.logger']['type']);
     }
 
+    public function test_failure_cache_configuration()
+    {
+        $configs = [
+            [
+                'instrumentation_key' => 'test_key',
+                'failure_cache_service_id' => 'failure_cache_id'
+            ],
+        ];
+
+        $config = $this->process($configs);
+
+        $this->assertEquals('failure_cache_id', $config['failure_cache_service_id']);
+    }
+
     protected function process($configs)
     {
         $processor = new Processor();

--- a/Tests/Listener/KernelTerminateListenerTest.php
+++ b/Tests/Listener/KernelTerminateListenerTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare (strict_types=1);
+
+namespace AppInsightsPHP\Symfony\AppInsightsPHPBundle\Tests\Listener;
+
+use AppInsightsPHP\Client\Client;
+use AppInsightsPHP\Client\Configuration;
+use AppInsightsPHP\Symfony\AppInsightsPHPBundle\Listener\KernelTerminateListener;
+use ApplicationInsights\Channel\Telemetry_Channel;
+use ApplicationInsights\Telemetry_Client;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\SimpleCache\CacheInterface;
+
+final class KernelTerminateListenerTest extends TestCase
+{
+    public function test_do_nothing_when_telemetry_queue_is_empty()
+    {
+        $client = new Client($telemetryClientMock = $this->createMock(Telemetry_Client::class), Configuration::createDefault());
+
+        $telemetryClientMock->method('getChannel')->willReturn($telemetryChannelMock = $this->createMock(Telemetry_Channel::class));
+        $telemetryChannelMock->method('getQueue')->willReturn([]);
+
+        $telemetryClientMock->expects($this->never())
+            ->method('flush');
+
+        $listener = new KernelTerminateListener($client);
+
+        $listener->onTerminate();
+    }
+
+    public function test_successful_flush()
+    {
+        $client = new Client($telemetryClientMock = $this->createMock(Telemetry_Client::class), Configuration::createDefault());
+
+        $telemetryClientMock->method('getChannel')->willReturn($telemetryChannelMock = $this->createMock(Telemetry_Channel::class));
+        $telemetryChannelMock->method('getQueue')->willReturn(['some_log_entry']);
+
+        $telemetryClientMock->expects($this->once())
+            ->method('flush');
+
+        $listener = new KernelTerminateListener($client);
+
+        $listener->onTerminate();
+    }
+
+    public function test_fallback_logger_during_flush_unexpected_exception()
+    {
+        $client = new Client($telemetryClientMock = $this->createMock(Telemetry_Client::class), Configuration::createDefault());
+
+        $telemetryClientMock->method('getChannel')->willReturn($telemetryChannelMock = $this->createMock(Telemetry_Channel::class));
+        $telemetryChannelMock->method('getQueue')->willReturn(['some_log_entry']);
+        $telemetryChannelMock->method('getSerializedQueue')->willReturn(\json_encode(['some_log_entry']));
+
+        $telemetryClientMock->method('flush')
+            ->willThrowException(new \RuntimeException('Unexpected API exception'));
+
+        $listener = new KernelTerminateListener($client, null, $loggerMock = $this->createMock(LoggerInterface::class));
+
+        $loggerMock->expects($this->once())
+            ->method('error')
+            ->with('Exception occurred while flushing App Insights Telemetry Client: Unexpected API exception', ['some_log_entry']);
+
+        $listener->onTerminate();
+    }
+
+    public function test_adding_queue_to_failure_cache_on_unexpected_api_exception_and_cache_is_empty()
+    {
+        $client = new Client($telemetryClientMock = $this->createMock(Telemetry_Client::class), Configuration::createDefault());
+
+        $telemetryClientMock->method('getChannel')->willReturn($telemetryChannelMock = $this->createMock(Telemetry_Channel::class));
+        $telemetryChannelMock->method('getQueue')->willReturn(['some_log_entry']);
+
+        $telemetryClientMock->method('flush')
+            ->willThrowException(new \RuntimeException('Unexpected API exception'));
+
+        $listener = new KernelTerminateListener($client, $cacheMock = $this->createMock(CacheInterface::class));
+
+        $cacheMock->method('has')
+            ->willReturn(false);
+
+        $cacheMock->expects($this->once())
+            ->method('set')
+            ->with(KernelTerminateListener::CACHE_CHANNEL_KEY, serialize(['some_log_entry']), KernelTerminateListener::CACHE_CHANNEL_TTL_SEC);
+
+        $listener->onTerminate();
+    }
+
+    public function test_adding_queue_to_failure_cache_on_unexpected_api_exception_and_cache_is_not_empty()
+    {
+        $client = new Client($telemetryClientMock = $this->createMock(Telemetry_Client::class), Configuration::createDefault());
+
+        $telemetryClientMock->method('getChannel')->willReturn($telemetryChannelMock = $this->createMock(Telemetry_Channel::class));
+        $telemetryChannelMock->method('getQueue')->willReturn(['some_log_entry']);
+
+        $telemetryClientMock->method('flush')
+            ->willThrowException(new \RuntimeException('Unexpected API exception'));
+
+        $listener = new KernelTerminateListener($client, $cacheMock = $this->createMock(CacheInterface::class));
+
+        $cacheMock->method('has')
+            ->willReturn(true);
+
+        $cacheMock->method('get')
+            ->willReturn(serialize(['some_older_entry']));
+
+        $cacheMock->expects($this->once())
+            ->method('set')
+            ->with(KernelTerminateListener::CACHE_CHANNEL_KEY, serialize(['some_older_entry', 'some_log_entry']), KernelTerminateListener::CACHE_CHANNEL_TTL_SEC);
+
+        $listener->onTerminate();
+    }
+
+    public function test_flush_when_cache_is_not_empty()
+    {
+        $client = new Client($telemetryClientMock = $this->createMock(Telemetry_Client::class), Configuration::createDefault());
+
+        $telemetryClientMock->method('getChannel')->willReturn($telemetryChannelMock = $this->createMock(Telemetry_Channel::class));
+        $telemetryChannelMock->method('getQueue')->willReturn(['some_log_entry']);
+
+        $listener = new KernelTerminateListener($client, $cacheMock = $this->createMock(CacheInterface::class));
+
+        $cacheMock->method('has')
+            ->willReturn(true);
+
+        $cacheMock->method('get')
+            ->willReturn(serialize(['some_older_entry']));
+
+        $cacheMock->expects($this->once())
+            ->method('delete')
+            ->with(KernelTerminateListener::CACHE_CHANNEL_KEY);
+
+        $telemetryChannelMock->expects($this->once())
+            ->method('setQueue')
+            ->with(['some_older_entry', 'some_log_entry']);
+
+        $telemetryClientMock->expects($this->once())
+            ->method('flush');
+
+        $listener->onTerminate();
+    }
+}

--- a/Tests/Listener/KernelTerminateListenerTest.php
+++ b/Tests/Listener/KernelTerminateListenerTest.php
@@ -1,6 +1,15 @@
 <?php
 
-declare (strict_types=1);
+declare(strict_types=1);
+
+/*
+ * This file is part of the App Insights PHP project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace AppInsightsPHP\Symfony\AppInsightsPHPBundle\Tests\Listener;
 
@@ -51,7 +60,7 @@ final class KernelTerminateListenerTest extends TestCase
 
         $telemetryClientMock->method('getChannel')->willReturn($telemetryChannelMock = $this->createMock(Telemetry_Channel::class));
         $telemetryChannelMock->method('getQueue')->willReturn(['some_log_entry']);
-        $telemetryChannelMock->method('getSerializedQueue')->willReturn(\json_encode(['some_log_entry']));
+        $telemetryChannelMock->method('getSerializedQueue')->willReturn(json_encode(['some_log_entry']));
 
         $telemetryClientMock->method('flush')
             ->willThrowException(new \RuntimeException('Unexpected API exception'));


### PR DESCRIPTION
This mechanism should reduce amount of data lost during app insights crashes 