### PR TITLE
Improve registration of symfony listeners

### DIFF
--- a/DependencyInjection/AppInsightsPHPExtension.php
+++ b/DependencyInjection/AppInsightsPHPExtension.php
@@ -41,21 +41,6 @@ final class AppInsightsPHPExtension extends Extension
         $container->setParameter('app_insights_php.instrumentation_key', $config['instrumentation_key']);
         $container->setParameter('app_insights_php.doctrine.track_dependency', $config['doctrine']['track_dependency']);
 
-        if ((bool) $config['fallback_logger']) {
-            $container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')
-                ->replaceArgument(2, new Reference($config['fallback_logger']['service_id']));
-
-            if (isset($config['fallback_logger']['monolog_channel'])) {
-                $container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')
-                    ->addTag('monolog.logger', ['channel' => $config['fallback_logger']['monolog_channel']]);
-            }
-        }
-
-        if (isset($config['failure_cache_service_id'])) {
-            $container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')
-                ->replaceArgument(1, new Reference($config['failure_cache_service_id']));
-        }
-
         // Make autowiring possible
         $container->setAlias(Client::class, 'app_insights_php.telemetry')->setPublic(true);
 
@@ -91,6 +76,26 @@ final class AppInsightsPHPExtension extends Extension
         );
 
         $container->getDefinition('app_insights_php.telemetry.factory')->replaceArgument(1, new Reference('app_insights_php.configuration'));
+
+        // Symfony
+        if ($config['enabled'] && (bool) $config['instrumentation_key']) {
+            $loader->load('app_insights_php_symfony.xml');
+
+            if ((bool) $config['fallback_logger']) {
+                $container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')
+                    ->replaceArgument(2, new Reference($config['fallback_logger']['service_id']));
+
+                if (isset($config['fallback_logger']['monolog_channel'])) {
+                    $container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')
+                        ->addTag('monolog.logger', ['channel' => $config['fallback_logger']['monolog_channel']]);
+                }
+            }
+
+            if (isset($config['failure_cache_service_id'])) {
+                $container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')
+                    ->replaceArgument(1, new Reference($config['failure_cache_service_id']));
+            }
+        }
 
         // Twig
         if (class_exists('Twig_Environment')) {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ final class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->booleanNode('enabled')->defaultTrue()->end()
-                ->scalarNode('instrumentation_key')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('instrumentation_key')->isRequired()->end()
                 ->arrayNode('fallback_logger')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/Resources/config/app_insights_php.xml
+++ b/Resources/config/app_insights_php.xml
@@ -14,26 +14,5 @@
         <service id="app_insights_php.telemetry" class="ApplicationInsights\Client\Client" public="true">
             <factory service="app_insights_php.telemetry.factory" method="create" />
         </service>
-
-        <service id="app_insights_php.symfony.listener.http_request" class="AppInsightsPHP\Symfony\AppInsightsPHPBundle\Listener\HttpRequestListener">
-            <argument type="service" id="app_insights_php.telemetry" />
-
-            <tag name="kernel.event_subscriber" />
-        </service>
-
-        <service id="app_insights_php.symfony.listener.kernel_terminate" class="AppInsightsPHP\Symfony\AppInsightsPHPBundle\Listener\KernelTerminateListener">
-            <argument type="service" id="app_insights_php.telemetry" />
-            <argument/> <!-- Replaced by AppInsightsPHPBundleExtension - cache -->
-            <argument/> <!-- Replaced by AppInsightsPHPBundleExtension - logger -->
-
-            <tag name="kernel.event_subscriber" />
-        </service>
-
-        <service id="app_insights_php.symfony.listener.exception" class="AppInsightsPHP\Symfony\AppInsightsPHPBundle\Listener\ExceptionListener">
-            <argument type="service" id="app_insights_php.telemetry" />
-            <argument type="collection" />
-
-            <tag name="kernel.event_subscriber" />
-        </service>
     </services>
 </container>

--- a/Resources/config/app_insights_php_symfony.xml
+++ b/Resources/config/app_insights_php_symfony.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults public="false" />
+
+        <service id="app_insights_php.symfony.listener.http_request" class="AppInsightsPHP\Symfony\AppInsightsPHPBundle\Listener\HttpRequestListener">
+            <argument type="service" id="app_insights_php.telemetry" />
+
+            <tag name="kernel.event_subscriber" />
+        </service>
+
+        <service id="app_insights_php.symfony.listener.kernel_terminate" class="AppInsightsPHP\Symfony\AppInsightsPHPBundle\Listener\KernelTerminateListener">
+            <argument type="service" id="app_insights_php.telemetry" />
+            <argument/> <!-- Replaced by AppInsightsPHPBundleExtension - failure cache -->
+            <argument/> <!-- Replaced by AppInsightsPHPBundleExtension - logger -->
+
+            <tag name="kernel.event_subscriber" />
+        </service>
+
+        <service id="app_insights_php.symfony.listener.exception" class="AppInsightsPHP\Symfony\AppInsightsPHPBundle\Listener\ExceptionListener">
+            <argument type="service" id="app_insights_php.telemetry" />
+            <argument type="collection" />
+
+            <tag name="kernel.event_subscriber" />
+        </service>
+    </services>
+</container>

--- a/Tests/DependencyInjection/AppInsightsPHPExtensionTest.php
+++ b/Tests/DependencyInjection/AppInsightsPHPExtensionTest.php
@@ -75,6 +75,63 @@ final class AppInsightsPHPExtensionTest extends TestCase
         $this->assertInstanceOf(Client::class, $this->container->get('app_insights_php.telemetry'));
     }
 
+    public function test_configuration_when_enabled_is_set_to_false()
+    {
+        $extension = new AppInsightsPHPExtension();
+        $extension->load(
+            [[
+                'enabled' => false,
+                'instrumentation_key' => 'test_key',
+            ]],
+            $this->container
+        );
+
+        $this->assertTrue($this->container->hasDefinition('app_insights_php.telemetry'));
+        $this->assertTrue($this->container->hasParameter('app_insights_php.instrumentation_key'));
+
+        $this->assertFalse($this->container->hasDefinition('app_insights_php.doctrine.logger.app_insights'));
+
+        $this->assertFalse($this->container->get('app_insights_php.configuration')->isEnabled());
+        $this->assertTrue($this->container->get('app_insights_php.configuration.exceptions')->isEnabled());
+        $this->assertTrue($this->container->get('app_insights_php.configuration.traces')->isEnabled());
+        $this->assertTrue($this->container->get('app_insights_php.configuration.dependencies')->isEnabled());
+        $this->assertTrue($this->container->get('app_insights_php.configuration.requests')->isEnabled());
+
+        $this->assertFalse($this->container->hasDefinition('app_insights_php.symfony.listener.http_request'));
+        $this->assertFalse($this->container->hasDefinition('app_insights_php.symfony.listener.kernel_terminate'));
+        $this->assertFalse($this->container->hasDefinition('app_insights_php.symfony.listener.exception'));
+
+        $this->assertInstanceOf(Client::class, $this->container->get('app_insights_php.telemetry'));
+    }
+
+    public function test_configuration_when_instrumentation_key_is_empty()
+    {
+        $extension = new AppInsightsPHPExtension();
+        $extension->load(
+            [[
+                'instrumentation_key' => '',
+            ]],
+            $this->container
+        );
+
+        $this->assertTrue($this->container->hasDefinition('app_insights_php.telemetry'));
+        $this->assertTrue($this->container->hasParameter('app_insights_php.instrumentation_key'));
+
+        $this->assertFalse($this->container->hasDefinition('app_insights_php.doctrine.logger.app_insights'));
+
+        $this->assertTrue($this->container->get('app_insights_php.configuration')->isEnabled());
+        $this->assertTrue($this->container->get('app_insights_php.configuration.exceptions')->isEnabled());
+        $this->assertTrue($this->container->get('app_insights_php.configuration.traces')->isEnabled());
+        $this->assertTrue($this->container->get('app_insights_php.configuration.dependencies')->isEnabled());
+        $this->assertTrue($this->container->get('app_insights_php.configuration.requests')->isEnabled());
+
+        $this->assertFalse($this->container->hasDefinition('app_insights_php.symfony.listener.http_request'));
+        $this->assertFalse($this->container->hasDefinition('app_insights_php.symfony.listener.kernel_terminate'));
+        $this->assertFalse($this->container->hasDefinition('app_insights_php.symfony.listener.exception'));
+
+        $this->assertInstanceOf(Client::class, $this->container->get('app_insights_php.telemetry'));
+    }
+
     public function test_fallback_logger_configuration()
     {
         $extension = new AppInsightsPHPExtension();

--- a/Tests/Twig/TelemetryExtensionTest.php
+++ b/Tests/Twig/TelemetryExtensionTest.php
@@ -91,4 +91,22 @@ TWIG
             , $twigExtension->appInsightsPHP('norbert@orzechowicz.pl')
         );
     }
+
+    public function test_app_insights_php_function_with_empty_instrumentation_key()
+    {
+        $config = Configuration::createDefault();
+
+        $client = (new ClientFactory('', $config))->create();
+        $client->getContext()->getOperationContext()->setId('operation_id');
+        $twigExtension = new TelemetryExtension($client);
+
+        $this->assertSame(
+            <<<TWIG
+<script type="text/javascript">
+//app_insights_php instrumentation_key is empty, please check bundle configuration.
+</script>
+TWIG
+            , $twigExtension->appInsightsPHP('norbert@orzechowicz.pl')
+        );
+    }
 }

--- a/Twig/TelemetryExtension.php
+++ b/Twig/TelemetryExtension.php
@@ -40,7 +40,8 @@ final class TelemetryExtension extends AbstractExtension
     {
         $script = "<script type=\"text/javascript\">\n";
         if ($this->client->configuration()->isEnabled()) {
-            $script .= sprintf(<<<JS
+            if ($this->client->getContext()->getInstrumentationKey()) {
+                $script .= sprintf(<<<JS
 var appInsights=window.appInsights||function(a){
   function b(a){c[a]=function(){var b=arguments;c.queue.push(function(){c[a].apply(c,b)})}}var c={config:a},d=document,e=window;setTimeout(function(){var b=d.createElement("script");b.src=a.url||"https://az416426.vo.msecnd.net/scripts/a/ai.0.js",d.getElementsByTagName("script")[0].parentNode.appendChild(b)});try{c.cookie=d.cookie}catch(a){}c.queue=[];for(var f=["Event","Exception","Metric","PageView","Trace","Dependency"];f.length;)b("track"+f.pop());if(b("setAuthenticatedUserContext"),b("clearAuthenticatedUserContext"),b("startTrackEvent"),b("stopTrackEvent"),b("startTrackPage"),b("stopTrackPage"),b("flush"),!a.disableExceptionTracking){f="onerror",b("_"+f);var g=e[f];e[f]=function(a,b,d,e,h){var i=g&&g(a,b,d,e,h);return!0!==i&&c["_"+f](a,b,d,e,h),i}}return c
   }({
@@ -52,15 +53,18 @@ window.appInsights.queue.push(function () {
     appInsights.context.operation.id = '%s';
 });\n
 JS
-                , $this->client->getContext()->getInstrumentationKey(),
-                $this->client->getContext()->getOperationContext()->getId()
-            );
+                    , $this->client->getContext()->getInstrumentationKey(),
+                    $this->client->getContext()->getOperationContext()->getId()
+                );
 
-            if ($userId) {
-                $script .= sprintf("window.appInsights.setAuthenticatedUserContext(\"%s\");\n", $userId);
+                if ($userId) {
+                    $script .= sprintf("window.appInsights.setAuthenticatedUserContext(\"%s\");\n", $userId);
+                }
+
+                $script .= "window.appInsights.trackPageView();\n";
+            } else {
+                $script .= "//app_insights_php instrumentation_key is empty, please check bundle configuration.\n";
             }
-
-            $script .= "window.appInsights.trackPageView();\n";
         } else {
             $script .= "//app_insights_php integration is disabled, please check bundle configuration.\n";
         }


### PR DESCRIPTION
This PR allows to use empty instrumentation_key (to simplify dev environment configuration). 
It also checks first if `enabled: true` before registering symfony listeners. 