### PR TITLE
Move checking instrumentation key directly into listeners

### DIFF
--- a/DependencyInjection/AppInsightsPHPExtension.php
+++ b/DependencyInjection/AppInsightsPHPExtension.php
@@ -78,8 +78,16 @@ final class AppInsightsPHPExtension extends Extension
         $container->getDefinition('app_insights_php.telemetry.factory')->replaceArgument(1, new Reference('app_insights_php.configuration'));
 
         // Symfony
-        if ($config['enabled'] && (bool) $config['instrumentation_key']) {
+        if ($config['enabled']) {
             $loader->load('app_insights_php_symfony.xml');
+
+            if (isset($config['failure_cache_service_id'])) {
+                $container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')
+                    ->replaceArgument(1, new Reference($config['failure_cache_service_id']));
+            } else {
+                $container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')
+                    ->replaceArgument(1, null);
+            }
 
             if ((bool) $config['fallback_logger']) {
                 $container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')
@@ -89,11 +97,9 @@ final class AppInsightsPHPExtension extends Extension
                     $container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')
                         ->addTag('monolog.logger', ['channel' => $config['fallback_logger']['monolog_channel']]);
                 }
-            }
-
-            if (isset($config['failure_cache_service_id'])) {
+            } else {
                 $container->getDefinition('app_insights_php.symfony.listener.kernel_terminate')
-                    ->replaceArgument(1, new Reference($config['failure_cache_service_id']));
+                    ->replaceArgument(2, null);
             }
         }
 

--- a/Listener/ExceptionListener.php
+++ b/Listener/ExceptionListener.php
@@ -38,6 +38,11 @@ final class ExceptionListener implements EventSubscriberInterface
 
     public function onException(GetResponseForExceptionEvent $event)
     {
+        if (!$this->telemetryClient->getContext()->getInstrumentationKey()) {
+            // instrumentation key is emtpy
+            return;
+        }
+
         if ($this->exceptionLogged) {
             return;
         }

--- a/Listener/HttpRequestListener.php
+++ b/Listener/HttpRequestListener.php
@@ -46,6 +46,11 @@ final class HttpRequestListener implements EventSubscriberInterface
             return;
         }
 
+        if (!$this->telemetryClient->getContext()->getInstrumentationKey()) {
+            // instrumentation key is emtpy
+            return;
+        }
+
         $this->requestStartTime = time();
         $this->requestStartTimeMs = (int) round(microtime(true) * 1000, 1);
 
@@ -69,6 +74,13 @@ final class HttpRequestListener implements EventSubscriberInterface
     public function onKernelResponse(FilterResponseEvent $event)
     {
         if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        if (!$this->telemetryClient->getContext()->getInstrumentationKey()) {
+            // instrumentation key is emtpy
+            echo 'INSTRUMENTATION KEY IS EMPTY';
+
             return;
         }
 

--- a/Listener/HttpRequestListener.php
+++ b/Listener/HttpRequestListener.php
@@ -79,8 +79,6 @@ final class HttpRequestListener implements EventSubscriberInterface
 
         if (!$this->telemetryClient->getContext()->getInstrumentationKey()) {
             // instrumentation key is emtpy
-            echo 'INSTRUMENTATION KEY IS EMPTY';
-
             return;
         }
 

--- a/Listener/KernelTerminateListener.php
+++ b/Listener/KernelTerminateListener.php
@@ -51,6 +51,11 @@ final class KernelTerminateListener implements EventSubscriberInterface
 
     public function onTerminate()
     {
+        if (!$this->telemetryClient->getContext()->getInstrumentationKey()) {
+            // instrumentation key is emtpy
+            return;
+        }
+
         if (!\count($this->telemetryClient->getChannel()->getQueue())) {
             // telemetry client queue is empty
             return;

--- a/Resources/config/app_insights_php_symfony.xml
+++ b/Resources/config/app_insights_php_symfony.xml
@@ -14,8 +14,8 @@
 
         <service id="app_insights_php.symfony.listener.kernel_terminate" class="AppInsightsPHP\Symfony\AppInsightsPHPBundle\Listener\KernelTerminateListener">
             <argument type="service" id="app_insights_php.telemetry" />
-            <argument on-invalid="null"/> <!-- Replaced by AppInsightsPHPBundleExtension - failure cache -->
-            <argument on-invalid="null"/> <!-- Replaced by AppInsightsPHPBundleExtension - logger -->
+            <argument /> <!-- Replaced by AppInsightsPHPBundleExtension - failure cache -->
+            <argument /> <!-- Replaced by AppInsightsPHPBundleExtension - logger -->
 
             <tag name="kernel.event_subscriber" />
         </service>

--- a/Resources/config/app_insights_php_symfony.xml
+++ b/Resources/config/app_insights_php_symfony.xml
@@ -14,8 +14,8 @@
 
         <service id="app_insights_php.symfony.listener.kernel_terminate" class="AppInsightsPHP\Symfony\AppInsightsPHPBundle\Listener\KernelTerminateListener">
             <argument type="service" id="app_insights_php.telemetry" />
-            <argument/> <!-- Replaced by AppInsightsPHPBundleExtension - failure cache -->
-            <argument/> <!-- Replaced by AppInsightsPHPBundleExtension - logger -->
+            <argument on-invalid="null"/> <!-- Replaced by AppInsightsPHPBundleExtension - failure cache -->
+            <argument on-invalid="null"/> <!-- Replaced by AppInsightsPHPBundleExtension - logger -->
 
             <tag name="kernel.event_subscriber" />
         </service>

--- a/Tests/DependencyInjection/AppInsightsPHPExtensionTest.php
+++ b/Tests/DependencyInjection/AppInsightsPHPExtensionTest.php
@@ -104,34 +104,6 @@ final class AppInsightsPHPExtensionTest extends TestCase
         $this->assertInstanceOf(Client::class, $this->container->get('app_insights_php.telemetry'));
     }
 
-    public function test_configuration_when_instrumentation_key_is_empty()
-    {
-        $extension = new AppInsightsPHPExtension();
-        $extension->load(
-            [[
-                'instrumentation_key' => '',
-            ]],
-            $this->container
-        );
-
-        $this->assertTrue($this->container->hasDefinition('app_insights_php.telemetry'));
-        $this->assertTrue($this->container->hasParameter('app_insights_php.instrumentation_key'));
-
-        $this->assertFalse($this->container->hasDefinition('app_insights_php.doctrine.logger.app_insights'));
-
-        $this->assertTrue($this->container->get('app_insights_php.configuration')->isEnabled());
-        $this->assertTrue($this->container->get('app_insights_php.configuration.exceptions')->isEnabled());
-        $this->assertTrue($this->container->get('app_insights_php.configuration.traces')->isEnabled());
-        $this->assertTrue($this->container->get('app_insights_php.configuration.dependencies')->isEnabled());
-        $this->assertTrue($this->container->get('app_insights_php.configuration.requests')->isEnabled());
-
-        $this->assertFalse($this->container->hasDefinition('app_insights_php.symfony.listener.http_request'));
-        $this->assertFalse($this->container->hasDefinition('app_insights_php.symfony.listener.kernel_terminate'));
-        $this->assertFalse($this->container->hasDefinition('app_insights_php.symfony.listener.exception'));
-
-        $this->assertInstanceOf(Client::class, $this->container->get('app_insights_php.telemetry'));
-    }
-
     public function test_fallback_logger_configuration()
     {
         $extension = new AppInsightsPHPExtension();

--- a/Tests/Listener/KernelTerminateListenerTest.php
+++ b/Tests/Listener/KernelTerminateListenerTest.php
@@ -18,17 +18,37 @@ use AppInsightsPHP\Client\Configuration;
 use AppInsightsPHP\Symfony\AppInsightsPHPBundle\Listener\KernelTerminateListener;
 use ApplicationInsights\Channel\Telemetry_Channel;
 use ApplicationInsights\Telemetry_Client;
+use ApplicationInsights\Telemetry_Context;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\CacheInterface;
 
 final class KernelTerminateListenerTest extends TestCase
 {
+    public function test_do_nothing_when_instrumentation_key_is_empty()
+    {
+        $client = new Client($telemetryClientMock = $this->createMock(Telemetry_Client::class), Configuration::createDefault());
+
+        $telemetryClientMock->method('getChannel')->willReturn($telemetryChannelMock = $this->createMock(Telemetry_Channel::class));
+        $telemetryClientMock->method('getContext')->willReturn($telemetryContextMock = $this->createMock(Telemetry_Context::class));
+        $telemetryContextMock->method('getInstrumentationKey')->willReturn('');
+        $telemetryChannelMock->method('getQueue')->willReturn([]);
+
+        $telemetryClientMock->expects($this->never())
+            ->method('flush');
+
+        $listener = new KernelTerminateListener($client);
+
+        $listener->onTerminate();
+    }
+
     public function test_do_nothing_when_telemetry_queue_is_empty()
     {
         $client = new Client($telemetryClientMock = $this->createMock(Telemetry_Client::class), Configuration::createDefault());
 
         $telemetryClientMock->method('getChannel')->willReturn($telemetryChannelMock = $this->createMock(Telemetry_Channel::class));
+        $telemetryClientMock->method('getContext')->willReturn($telemetryContextMock = $this->createMock(Telemetry_Context::class));
+        $telemetryContextMock->method('getInstrumentationKey')->willReturn('instrumentation_key');
         $telemetryChannelMock->method('getQueue')->willReturn([]);
 
         $telemetryClientMock->expects($this->never())
@@ -44,6 +64,8 @@ final class KernelTerminateListenerTest extends TestCase
         $client = new Client($telemetryClientMock = $this->createMock(Telemetry_Client::class), Configuration::createDefault());
 
         $telemetryClientMock->method('getChannel')->willReturn($telemetryChannelMock = $this->createMock(Telemetry_Channel::class));
+        $telemetryClientMock->method('getContext')->willReturn($telemetryContextMock = $this->createMock(Telemetry_Context::class));
+        $telemetryContextMock->method('getInstrumentationKey')->willReturn('instrumentation_key');
         $telemetryChannelMock->method('getQueue')->willReturn(['some_log_entry']);
 
         $telemetryClientMock->expects($this->once())
@@ -59,6 +81,8 @@ final class KernelTerminateListenerTest extends TestCase
         $client = new Client($telemetryClientMock = $this->createMock(Telemetry_Client::class), Configuration::createDefault());
 
         $telemetryClientMock->method('getChannel')->willReturn($telemetryChannelMock = $this->createMock(Telemetry_Channel::class));
+        $telemetryClientMock->method('getContext')->willReturn($telemetryContextMock = $this->createMock(Telemetry_Context::class));
+        $telemetryContextMock->method('getInstrumentationKey')->willReturn('instrumentation_key');
         $telemetryChannelMock->method('getQueue')->willReturn(['some_log_entry']);
         $telemetryChannelMock->method('getSerializedQueue')->willReturn(json_encode(['some_log_entry']));
 
@@ -79,6 +103,8 @@ final class KernelTerminateListenerTest extends TestCase
         $client = new Client($telemetryClientMock = $this->createMock(Telemetry_Client::class), Configuration::createDefault());
 
         $telemetryClientMock->method('getChannel')->willReturn($telemetryChannelMock = $this->createMock(Telemetry_Channel::class));
+        $telemetryClientMock->method('getContext')->willReturn($telemetryContextMock = $this->createMock(Telemetry_Context::class));
+        $telemetryContextMock->method('getInstrumentationKey')->willReturn('instrumentation_key');
         $telemetryChannelMock->method('getQueue')->willReturn(['some_log_entry']);
 
         $telemetryClientMock->method('flush')
@@ -101,6 +127,8 @@ final class KernelTerminateListenerTest extends TestCase
         $client = new Client($telemetryClientMock = $this->createMock(Telemetry_Client::class), Configuration::createDefault());
 
         $telemetryClientMock->method('getChannel')->willReturn($telemetryChannelMock = $this->createMock(Telemetry_Channel::class));
+        $telemetryClientMock->method('getContext')->willReturn($telemetryContextMock = $this->createMock(Telemetry_Context::class));
+        $telemetryContextMock->method('getInstrumentationKey')->willReturn('instrumentation_key');
         $telemetryChannelMock->method('getQueue')->willReturn(['some_log_entry']);
 
         $telemetryClientMock->method('flush')
@@ -126,6 +154,8 @@ final class KernelTerminateListenerTest extends TestCase
         $client = new Client($telemetryClientMock = $this->createMock(Telemetry_Client::class), Configuration::createDefault());
 
         $telemetryClientMock->method('getChannel')->willReturn($telemetryChannelMock = $this->createMock(Telemetry_Channel::class));
+        $telemetryClientMock->method('getContext')->willReturn($telemetryContextMock = $this->createMock(Telemetry_Context::class));
+        $telemetryContextMock->method('getInstrumentationKey')->willReturn('instrumentation_key');
         $telemetryChannelMock->method('getQueue')->willReturn(['some_log_entry']);
 
         $listener = new KernelTerminateListener($client, $cacheMock = $this->createMock(CacheInterface::class));


### PR DESCRIPTION
This PR fixes issue with instrumentation key passed through env vars. 
Previously `(bool) $config['instrumentation_key']` in bundle extension would always return true because env vars are processed only at runtime. 