### PR TITLE
Fix replace classes that have been removed from Symfony 5

### DIFF
--- a/Listener/ExceptionListener.php
+++ b/Listener/ExceptionListener.php
@@ -15,7 +15,7 @@ namespace AppInsightsPHP\Symfony\AppInsightsPHPBundle\Listener;
 
 use AppInsightsPHP\Client\Client;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 final class ExceptionListener implements EventSubscriberInterface
@@ -36,7 +36,7 @@ final class ExceptionListener implements EventSubscriberInterface
         ];
     }
 
-    public function onException(GetResponseForExceptionEvent $event)
+    public function onException(ExceptionEvent $event)
     {
         if (!$this->telemetryClient->getContext()->getInstrumentationKey()) {
             // instrumentation key is emtpy
@@ -47,7 +47,7 @@ final class ExceptionListener implements EventSubscriberInterface
             return;
         }
 
-        $this->telemetryClient->trackException($event->getException());
+        $this->telemetryClient->trackException($event->getThrowable());
         $this->exceptionLogged = true;
     }
 }

--- a/Listener/HttpRequestListener.php
+++ b/Listener/HttpRequestListener.php
@@ -16,8 +16,8 @@ namespace AppInsightsPHP\Symfony\AppInsightsPHPBundle\Listener;
 use AppInsightsPHP\Client\Client;
 use AppInsightsPHP\Symfony\AppInsightsPHPBundle\FlatArray;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 final class HttpRequestListener implements EventSubscriberInterface
@@ -41,7 +41,7 @@ final class HttpRequestListener implements EventSubscriberInterface
         ];
     }
 
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(RequestEvent $event)
     {
         if (!$event->isMasterRequest()) {
             return;
@@ -72,7 +72,7 @@ final class HttpRequestListener implements EventSubscriberInterface
         );
     }
 
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event)
     {
         if (!$event->isMasterRequest()) {
             return;


### PR DESCRIPTION
Sorry for the late reply. Thanks heaps for #25 and 0.2.3. I gave it a wirl and it looks like it's working. I just had to replace some classes that had been removed from Symfony 5.