### PR TITLE
[Symfony 6] Forward compatibility for the deprecated KernelEvent::isMasterRequest()

### DIFF
--- a/Listener/HttpRequestListener.php
+++ b/Listener/HttpRequestListener.php
@@ -45,7 +45,7 @@ final class HttpRequestListener implements EventSubscriberInterface
 
     public function onKernelRequest(RequestEvent $event) : void
     {
-        if (!$event->isMasterRequest()) {
+        if (!$this->isMainRequest($event)) {
             return;
         }
 
@@ -80,7 +80,7 @@ final class HttpRequestListener implements EventSubscriberInterface
 
     public function onKernelResponse(ResponseEvent $event) : void
     {
-        if (!$event->isMasterRequest()) {
+        if (!$this->isMainRequest($event)) {
             return;
         }
 
@@ -113,5 +113,13 @@ final class HttpRequestListener implements EventSubscriberInterface
                 'clientIps' => $request->getClientIps(),
             ]))()
         );
+    }
+
+    protected function isMainRequest(KernelEvent $event): bool
+    {
+        return method_exists($event, 'isMainRequest')
+            ? $event->isMainRequest()
+            : $event->isMasterRequest()
+        ;
     }
 }

--- a/Listener/HttpRequestListener.php
+++ b/Listener/HttpRequestListener.php
@@ -16,6 +16,7 @@ namespace AppInsightsPHP\Symfony\AppInsightsPHPBundle\Listener;
 use AppInsightsPHP\Client\Client;
 use AppInsightsPHP\Symfony\AppInsightsPHPBundle\FlatArray;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -115,11 +116,10 @@ final class HttpRequestListener implements EventSubscriberInterface
         );
     }
 
-    protected function isMainRequest(KernelEvent $event): bool
+    private function isMainRequest(KernelEvent $event) : bool
     {
-        return method_exists($event, 'isMainRequest')
+        return \method_exists($event, 'isMainRequest')
             ? $event->isMainRequest()
-            : $event->isMasterRequest()
-        ;
+            : $event->isMasterRequest();
     }
 }


### PR DESCRIPTION
Symfony\Component\HttpKernel\Event\KernelEvent::isMasterRequest() is deprecated, use isMainRequest() instead

<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    Forward compatibility for the deprecated KernelEvent::isMasterRequest()
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->